### PR TITLE
Refactor fmt formatters

### DIFF
--- a/cmake/modules/FetchSleipnir.cmake
+++ b/cmake/modules/FetchSleipnir.cmake
@@ -8,7 +8,7 @@ macro(fetch_sleipnir)
     FetchContent_Declare(
         sleipnir
         GIT_REPOSITORY https://github.com/SleipnirGroup/Sleipnir.git
-        GIT_TAG c8d2d861f19b8975be71f324433511550317cf0a
+        GIT_TAG 8011450bc05eade43085eabe92519e4772eb17b5
         CMAKE_ARGS -DBUILD_TESTING=OFF -DBUILD_BENCHMARKING=OFF -DINSTALL_GMOCK=OFF -DINSTALL_GTEST=OFF
     )
     FetchContent_MakeAvailable(sleipnir)

--- a/helixtrajectorycpp/src/cpp/Main.cpp
+++ b/helixtrajectorycpp/src/cpp/Main.cpp
@@ -107,8 +107,8 @@ int main() {
 
     // SIMPLE MOTION PROFILE
     // auto con = Constraint(TranslationConstraint(RectangularSet2d(0, 0)));
-    auto con = VelocityConstraint(RectangularSet2d(0, 0));
-    fmt::print("{}\n\n\n", con);
+    // auto con = VelocityConstraint(RectangularSet2d(0, 0));
+    // fmt::print("{}\n\n\n", con);
     HolonomicPath holonomicPath(HolonomicPath({
         HolonomicWaypoint(
             {TranslationConstraint(RectangularSet2d(0, 0)),         HeadingConstraint(0)},
@@ -122,7 +122,7 @@ int main() {
             {   VelocityConstraint(RectangularSet2d(0, 0)), AngularVelocityConstraint(0)},
             {},
             {},
-            30,
+            50,
             {InitialGuessPoint( 4,  0,  0.00)})},
         bumpers));
 

--- a/helixtrajectorycpp/src/cpp/Main.cpp
+++ b/helixtrajectorycpp/src/cpp/Main.cpp
@@ -76,9 +76,9 @@ int main() {
     //         {},
     //         10,
     //         {InitialGuessPoint( 4,  0,  0.00)})},
-    //     Obstacle(0, {{+0.5, +0.5}, {-0.5, +0.5}, {-0.5, -0.5}, {+0.5, -0.5}})));
+    //     bumpers));
 
-    // OBSTACLE TEST:
+    // HARD OBSTACLE TEST:
     // const std::vector<InitialGuessPoint> guesses = {
     //     { 0.00,  0.00, 0.00},
     //     { 2.00,  1.50, 0.00},
@@ -86,27 +86,40 @@ int main() {
     //     { 2.00, -1.50, -M_PI},
     //     { 0.00,  0.00, -M_PI}
     // };
-    // Obstacle cone(0.8, {{2.0, 0.0}});
+    // Obstacle cone(0.6, {{2.0, 0.0}});
     // HolonomicPath holonomicPath({
     //     HolonomicWaypoint({PoseConstraint(RectangularSet2d{ 0,  0},  0.00)}, {VelocityConstraint(RectangularSet2d{0, 0}), AngularVelocityConstraint(0.0)}, {                        }, {},   0, {InitialGuessPoint( 0,  0,   0.00)}),
-    //     HolonomicWaypoint({PoseConstraint(RectangularSet2d{ 0,  0}, -M_PI)}, {VelocityConstraint(RectangularSet2d{0, 0}), AngularVelocityConstraint(0.0)}, {ObstacleConstraint(cone)}, {}, 100,                             guesses)},
+    //     HolonomicWaypoint({PoseConstraint(RectangularSet2d{ 0,  0}, -M_PI)}, {VelocityConstraint(RectangularSet2d{0, 0}), AngularVelocityConstraint(0.0)}, {ObstacleConstraint(cone)}, {}, 40,                             guesses)},
+    //     bumpers);
+
+    // SIMPLE OBSTACLE TEST:
+    // const std::vector<InitialGuessPoint> guesses = {
+    //     { 0.00,  1.60, 0.00},
+    //     { 4.00,  0.00, 0.00}
+    // };
+    // Obstacle cone(1.0, {{2.0, 0.0}});
+    // HolonomicPath holonomicPath({
+    //     HolonomicWaypoint({PoseConstraint(RectangularSet2d{ 0,  0},  0.00)}, {VelocityConstraint(RectangularSet2d{0, 0}), AngularVelocityConstraint(0.0)}, {                        }, {},   0, {InitialGuessPoint( 0,  0,   0.00)}),
+    //     HolonomicWaypoint({PoseConstraint(RectangularSet2d{ 4,  0},  0.00)}, {VelocityConstraint(RectangularSet2d{0, 0}), AngularVelocityConstraint(0.0)}, {ObstacleConstraint(cone)}, {}, 36,                             guesses)},
     //     bumpers);
 
     // SIMPLE MOTION PROFILE
+    IntervalSet1d x = IntervalSet1d(1, 2);
+    fmt::print("{}", x);
     HolonomicPath holonomicPath(HolonomicPath({
         HolonomicWaypoint(
-            {Constraint(PoseConstraint(RectangularSet2d{ 0,  0},  0.00))},
-            {HolonomicConstraint(VelocityConstraint{RectangularSet2d(0, 0)}), HolonomicConstraint(AngularVelocityConstraint(0.0))},
+            {TranslationConstraint(RectangularSet2d(0, 0)),         HeadingConstraint(0)},
+            {   VelocityConstraint(RectangularSet2d(0, 0)), AngularVelocityConstraint(0)},
             {},
             {},
             0,
             {InitialGuessPoint( 0,  0,  0.00)}),
         HolonomicWaypoint(
-            {PoseConstraint(RectangularSet2d{ 4,  0},  0.00)},
-            {VelocityConstraint{RectangularSet2d{0, 0}}, AngularVelocityConstraint(0.0)},
+            {TranslationConstraint(RectangularSet2d(4, 0)),         HeadingConstraint(0)},
+            {   VelocityConstraint(RectangularSet2d(0, 0)), AngularVelocityConstraint(0)},
             {},
             {},
-            6,
+            30,
             {InitialGuessPoint( 4,  0,  0.00)})},
         bumpers));
 

--- a/helixtrajectorycpp/src/cpp/Main.cpp
+++ b/helixtrajectorycpp/src/cpp/Main.cpp
@@ -104,8 +104,9 @@ int main() {
     //     bumpers);
 
     // SIMPLE MOTION PROFILE
-    IntervalSet1d x = IntervalSet1d(1, 2);
-    fmt::print("{}", x);
+    // auto con = Constraint(TranslationConstraint(RectangularSet2d(0, 0)));
+    auto con = VelocityConstraint(RectangularSet2d(0, 0));
+    fmt::print("{}\n\n\n", con);
     HolonomicPath holonomicPath(HolonomicPath({
         HolonomicWaypoint(
             {TranslationConstraint(RectangularSet2d(0, 0)),         HeadingConstraint(0)},
@@ -123,11 +124,7 @@ int main() {
             {InitialGuessPoint( 4,  0,  0.00)})},
         bumpers));
 
-    SwerveSolution solution = OptimalTrajectoryGenerator::Generate(swerveDrivetrain, holonomicPath);
-
-    fmt::print("{}", solution);
-
-    // std::cout << "\nTrajectory:\n\n" << trajectory << std::endl;
-
-    std::cout << std::endl;
+    // SOLVE
+    // SwerveSolution solution = OptimalTrajectoryGenerator::Generate(swerveDrivetrain, holonomicPath);
+    // fmt::print("{}\n", solution);
 }

--- a/helixtrajectorycpp/src/cpp/Main.cpp
+++ b/helixtrajectorycpp/src/cpp/Main.cpp
@@ -38,7 +38,7 @@ int main() {
              SwerveModule(-0.6, +0.6, 0.04, 70, 2),
              SwerveModule(-0.6, -0.6, 0.04, 70, 2)});
 
-    fmt::print("{}\n", swerveDrivetrain.modules[0]);
+    fmt::print("{}\n", swerveDrivetrain);
 
     Obstacle bumpers(0, {{+0.5, +0.5}, {-0.5, +0.5}, {-0.5, -0.5}, {+0.5, -0.5}});
 

--- a/helixtrajectorycpp/src/cpp/Main.cpp
+++ b/helixtrajectorycpp/src/cpp/Main.cpp
@@ -38,6 +38,8 @@ int main() {
              SwerveModule(-0.6, +0.6, 0.04, 70, 2),
              SwerveModule(-0.6, -0.6, 0.04, 70, 2)});
 
+    fmt::print("{}\n", swerveDrivetrain.modules[0]);
+
     Obstacle bumpers(0, {{+0.5, +0.5}, {-0.5, +0.5}, {-0.5, -0.5}, {+0.5, -0.5}});
 
     // // CIRCULAR PATH
@@ -125,6 +127,6 @@ int main() {
         bumpers));
 
     // SOLVE
-    // SwerveSolution solution = OptimalTrajectoryGenerator::Generate(swerveDrivetrain, holonomicPath);
-    // fmt::print("{}\n", solution);
+    SwerveSolution solution = OptimalTrajectoryGenerator::Generate(swerveDrivetrain, holonomicPath);
+    fmt::print("{}\n", solution);
 }

--- a/helixtrajectorycpp/src/cpp/constraint/AngularVelocityConstraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/AngularVelocityConstraint.cpp
@@ -22,17 +22,3 @@ std::optional<SolutionError> AngularVelocityConstraint::CheckAngularVelocity(
     return std::nullopt;
 }
 }
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::AngularVelocityConstraint>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::AngularVelocityConstraint>::format(
-        const helixtrajectory::AngularVelocityConstraint& angularVelocityConstraint,
-        FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "ω {}",
-            angularVelocityConstraint.angularVelocityBound);
-}

--- a/helixtrajectorycpp/src/cpp/constraint/Constraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/Constraint.cpp
@@ -94,25 +94,3 @@ Constraint::Constraint(const ObstacleConstraint& obstacleConstraint)
         : constraint(obstacleConstraint) {
 }
 }
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::Constraint>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::Constraint>::format(
-        const helixtrajectory::Constraint& constraint,
-        FormatContext& ctx) {
-    using namespace helixtrajectory;
-    if (constraint.IsTranslationConstraint()) {
-        return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetTranslationConstraint());
-    } else if (constraint.IsHeadingConstraint()) {
-        return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetHeadingConstraint());
-    } else if (constraint.IsPoseConstraint()) {
-        return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetPoseConstraint());
-    } else /*if (constraint.IsObstacleConstraint())*/ {
-        return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetObstacleConstraint());
-    }
-}

--- a/helixtrajectorycpp/src/cpp/constraint/HeadingConstraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/HeadingConstraint.cpp
@@ -22,16 +22,3 @@ std::optional<SolutionError> HeadingConstraint::CheckHeading(double theta,
     return std::nullopt;
 }
 }
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::HeadingConstraint>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::HeadingConstraint>::format(
-        const helixtrajectory::HeadingConstraint& headingConstraint,
-        FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "heading {}", headingConstraint.headingBound);
-}

--- a/helixtrajectorycpp/src/cpp/constraint/HolonomicConstraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/HolonomicConstraint.cpp
@@ -61,20 +61,3 @@ HolonomicConstraint::HolonomicConstraint(const AngularVelocityConstraint& angula
         : constraint(angularVelocityConstraint) {
 }
 }
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::Constraint>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::HolonomicConstraint>::format(
-        const helixtrajectory::HolonomicConstraint& constraint,
-        FormatContext& ctx) {
-    if (constraint.IsVelocityConstraint()) {
-        return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetVelocityConstraint());
-    } else /*if (constraint.IsHeadingConstraint())*/ {
-        return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetAngularVelocityConstraint());
-    }
-}

--- a/helixtrajectorycpp/src/cpp/constraint/ObstacleConstraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/ObstacleConstraint.cpp
@@ -1,7 +1,5 @@
 #include "constraint/ObstacleConstraint.h"
 
-#include <fmt/format.h>
-
 #include "obstacle/Obstacle.h"
 
 namespace helixtrajectory {
@@ -9,18 +7,4 @@ namespace helixtrajectory {
 ObstacleConstraint::ObstacleConstraint(const Obstacle& obstacle)
         : obstacle(obstacle) {
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::ObstacleConstraint>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::ObstacleConstraint>::format(
-        const helixtrajectory::ObstacleConstraint& obstacleConstraint,
-        FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "");
-    // return fmt::format_to(ctx.out(), "heading {}", obstacleConstraint.obstacle);
 }

--- a/helixtrajectorycpp/src/cpp/constraint/PoseConstraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/PoseConstraint.cpp
@@ -2,8 +2,6 @@
 
 #include <optional>
 
-#include <fmt/format.h>
-
 #include "constraint/HeadingConstraint.h"
 #include "constraint/TranslationConstraint.h"
 #include "set/IntervalSet1d.h"
@@ -16,7 +14,8 @@ PoseConstraint::PoseConstraint(const Set2d& translationBound,
         : TranslationConstraint(translationBound), HeadingConstraint(headingBound) {
 }
 
-std::optional<SolutionError> PoseConstraint::CheckPose(double x, double y, double heading, const SolutionTolerances& tolerances) const noexcept {
+std::optional<SolutionError> PoseConstraint::CheckPose(double x, double y,
+        double heading, const SolutionTolerances& tolerances) const noexcept {
     auto translationCheck = CheckTranslation(x, y, tolerances);
     if (translationCheck.has_value()) {
         return translationCheck.value();

--- a/helixtrajectorycpp/src/cpp/constraint/TranslationConstraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/TranslationConstraint.cpp
@@ -22,17 +22,3 @@ std::optional<SolutionError> TranslationConstraint::CheckTranslation(
     return std::nullopt;
 }
 }
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::TranslationConstraint>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::TranslationConstraint>::format(
-        const helixtrajectory::TranslationConstraint& translationConstraint,
-        FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "jk");
-    // return fmt::format_to(ctx.out(), "heading {}", obstacleConstraint.obstacle);
-}

--- a/helixtrajectorycpp/src/cpp/constraint/VelocityConstraint.cpp
+++ b/helixtrajectorycpp/src/cpp/constraint/VelocityConstraint.cpp
@@ -22,16 +22,3 @@ std::optional<SolutionError> VelocityConstraint::CheckVelocity(
     return std::nullopt;
 }
 }
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::VelocityConstraint>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::VelocityConstraint>::format(
-        const helixtrajectory::VelocityConstraint& velocityConstraint,
-        FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "velocity {}", velocityConstraint.velocityBound);
-}

--- a/helixtrajectorycpp/src/cpp/optimization/SleipnirOpti.cpp
+++ b/helixtrajectorycpp/src/cpp/optimization/SleipnirOpti.cpp
@@ -2,6 +2,8 @@
 
 #include "optimization/SleipnirOpti.h"
 
+#include <cstddef>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -46,6 +48,7 @@ void SleipnirOpti::SetInitial(sleipnir::VariableMatrix& expression, double value
 void SleipnirOpti::Solve() {
     static sleipnir::SolverConfig config;
     config.diagnostics = true;
+    config.maxIterations = std::numeric_limits<int>::max();
     opti.Solve(config);
 }
 

--- a/helixtrajectorycpp/src/cpp/set/ConeSet2d.cpp
+++ b/helixtrajectorycpp/src/cpp/set/ConeSet2d.cpp
@@ -3,8 +3,6 @@
 #include <cmath>
 #include <optional>
 
-#include <fmt/format.h>
-
 #include "solution/SolutionChecking.h"
 
 namespace helixtrajectory {
@@ -26,17 +24,4 @@ std::optional<SolutionError> ConeSet2d::CheckVector(double xComp, double yComp, 
 bool ConeSet2d::IsValid() const noexcept {
     return thetaBound.Range() > 0.0 && thetaBound.Range() <= M_PI;
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::ConeSet2d>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::ConeSet2d>::format(
-        const helixtrajectory::ConeSet2d& coneSet,
-        FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "cone: θ = {}", coneSet.thetaBound);
 }

--- a/helixtrajectorycpp/src/cpp/set/EllipticalSet2d.cpp
+++ b/helixtrajectorycpp/src/cpp/set/EllipticalSet2d.cpp
@@ -5,8 +5,6 @@
 #include <optional>
 #include <string>
 
-#include <fmt/format.h>
-
 #include "solution/SolutionChecking.h"
 
 namespace helixtrajectory {
@@ -63,37 +61,4 @@ std::optional<SolutionError> EllipticalSet2d::CheckVector(
 bool EllipticalSet2d::IsValid() const noexcept {
     return xRadius > 0.0 && yRadius > 0.0;
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::EllipticalSet2d>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::EllipticalSet2d>::format(
-        const helixtrajectory::EllipticalSet2d& ellipticalSet,
-        FormatContext& ctx) {
-    std::string shape;
-    if (ellipticalSet.IsCircular()) {
-        shape = "circle";
-    } else {
-        shape = "ellipse";
-    }
-    using enum helixtrajectory::EllipticalSet2d::Direction;
-    std::string direction;
-    switch (ellipticalSet.direction) {
-        case kInside:
-            direction = "inside";
-            break;
-        case kCentered:
-            direction = "centered";
-            break;
-        case kOutside:
-            direction = "outside";
-            break;
-    }
-    return fmt::format_to(ctx.out(), "{}: {}, rₓ = {}, rᵧ = {}",
-            shape, direction, ellipticalSet.xRadius, ellipticalSet.yRadius);
 }

--- a/helixtrajectorycpp/src/cpp/set/IntervalSet1d.cpp
+++ b/helixtrajectorycpp/src/cpp/set/IntervalSet1d.cpp
@@ -4,8 +4,6 @@
 #include <limits>
 #include <optional>
 
-#include <fmt/format.h>
-
 #include "solution/SolutionChecking.h"
 
 namespace helixtrajectory {
@@ -57,20 +55,4 @@ std::optional<SolutionError> IntervalSet1d::CheckScalar(double scalar, const Sol
 bool IntervalSet1d::IsValid() const noexcept {
     return lower <= upper;
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::IntervalSet1d>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::IntervalSet1d>::format(
-        const helixtrajectory::IntervalSet1d& set1d, FormatContext& ctx) {
-    if (set1d.IsExact()) {
-        return fmt::format_to(ctx.out(), "= {}", set1d.lower);
-    } else {
-        return fmt::format_to(ctx.out(), "∈ [{}, {}]", set1d.lower, set1d.upper);
-    }
 }

--- a/helixtrajectorycpp/src/cpp/set/LinearSet2d.cpp
+++ b/helixtrajectorycpp/src/cpp/set/LinearSet2d.cpp
@@ -3,8 +3,6 @@
 #include <cmath>
 #include <optional>
 
-#include <fmt/format.h>
-
 #include "set/IntervalSet1d.h"
 #include "set/RectangularSet2d.h"
 #include "solution/SolutionChecking.h"
@@ -46,16 +44,4 @@ RectangularSet2d LinearSet2d::RBoundToRectangular(double theta, const IntervalSe
         return RectangularSet2d({lowerVectorX, upperVectorX}, IntervalSet1d::R1());
     }
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::LinearSet2d>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::LinearSet2d>::format(
-        const helixtrajectory::LinearSet2d& linearSet, FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "polar line: θ = {}", linearSet.theta);
 }

--- a/helixtrajectorycpp/src/cpp/set/RectangularSet2d.cpp
+++ b/helixtrajectorycpp/src/cpp/set/RectangularSet2d.cpp
@@ -3,8 +3,6 @@
 #include <cmath>
 #include <optional>
 
-#include <fmt/format.h>
-
 #include "set/IntervalSet1d.h"
 #include "solution/SolutionChecking.h"
 
@@ -38,16 +36,4 @@ std::optional<SolutionError> RectangularSet2d::CheckVector(double xComp,
 bool RectangularSet2d::IsValid() const noexcept {
     return xBound.IsValid() && yBound.IsValid();
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::RectangularSet2d>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::RectangularSet2d>::format(
-        const helixtrajectory::RectangularSet2d& rectangularSet, FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "x {}, y {}", rectangularSet.xBound, rectangularSet.yBound);
 }

--- a/helixtrajectorycpp/src/cpp/set/Set2d.cpp
+++ b/helixtrajectorycpp/src/cpp/set/Set2d.cpp
@@ -71,25 +71,3 @@ Set2d::Set2d(const ConeSet2d& coneSet2d)
         : set2d(coneSet2d) {
 }
 }
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::Set2d>::parse(
-        ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::Set2d>::format(
-        const helixtrajectory::Set2d& set2d,
-        FormatContext& ctx) {
-    using namespace helixtrajectory;
-    if (set2d.IsRectangular()) {
-        return fmt::format_to(ctx.out(), "2d {}", set2d.GetRectangular());
-    } else if (set2d.IsLinear()) {
-        return fmt::format_to(ctx.out(), "2d {}", set2d.GetLinear());
-    } else if (set2d.IsElliptical()) {
-        return fmt::format_to(ctx.out(), "2d {}", set2d.GetElliptical());
-    } else if (set2d.IsCone()) {
-        return fmt::format_to(ctx.out(), "2d {}", set2d.GetCone());
-    }
-}

--- a/helixtrajectorycpp/src/cpp/trajectory/HolonomicTrajectory.cpp
+++ b/helixtrajectorycpp/src/cpp/trajectory/HolonomicTrajectory.cpp
@@ -1,9 +1,6 @@
 #include <trajectory/HolonomicTrajectory.h>
 
-// #include <iostream>
-
-// #include <fmt/format.h>
-// #include <fmt/ranges.h>
+#include <memory>
 
 // #include "IncompatibleTrajectoryException.h"
 // #include "trajectory/HolonomicState.h"
@@ -17,15 +14,4 @@ HolonomicTrajectory::HolonomicTrajectory(const std::vector<HolonomicTrajectorySa
 HolonomicTrajectory::HolonomicTrajectory(std::vector<HolonomicTrajectorySample>&& samples)
       : samples(std::move(samples)) {
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::HolonomicTrajectory>::parse(ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::HolonomicTrajectory>::format(
-        const helixtrajectory::HolonomicTrajectory& trajectory, FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "traj1");
 }

--- a/helixtrajectorycpp/src/cpp/trajectory/HolonomicTrajectorySample.cpp
+++ b/helixtrajectorycpp/src/cpp/trajectory/HolonomicTrajectorySample.cpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-#include <fmt/format.h>
+// #include <fmt/format.h>
 
 namespace helixtrajectory {
 
@@ -53,19 +53,4 @@ std::ostream& operator<<(std::ostream& stream, const HolonomicTrajectorySample& 
             sample.x, sample.y, sample.heading,
             sample.velocityX, sample.velocityY, sample.angularVelocity);*/
 }
-}
-
-template<typename ParseContext>
-constexpr auto fmt::formatter<helixtrajectory::HolonomicTrajectorySample>::parse(ParseContext& ctx) {
-    return ctx.begin();
-}
-
-template<typename FormatContext>
-auto fmt::formatter<helixtrajectory::HolonomicTrajectorySample>::format(
-        const helixtrajectory::HolonomicTrajectorySample& sample, FormatContext& ctx) {
-    return fmt::format_to(ctx.out(),
-            "{{\"timestamp\": {}, \"x\": {}, \"y\": {}, \"heading\": {}, \"velocityX\": {}, \"velocityY\": {}, \"angularVelocity\": {}}}",
-            sample.timestamp,
-            sample.x, sample.y, sample.heading,
-            sample.velocityX, sample.velocityY, sample.angularVelocity);
 }

--- a/helixtrajectorycpp/src/include/constraint/AngularVelocityConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/AngularVelocityConstraint.h
@@ -24,9 +24,14 @@ template<>
 struct fmt::formatter<helixtrajectory::AngularVelocityConstraint> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
     auto format(const helixtrajectory::AngularVelocityConstraint& angularVelocityConstraint,
-            FormatContext& ctx);
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "ω {}",
+                angularVelocityConstraint.angularVelocityBound);
+    }
 };

--- a/helixtrajectorycpp/src/include/constraint/AngularVelocityConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/AngularVelocityConstraint.h
@@ -23,8 +23,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::AngularVelocityConstraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/Constraint.h
+++ b/helixtrajectorycpp/src/include/constraint/Constraint.h
@@ -94,8 +94,7 @@ private:
 template<>
 struct fmt::formatter<helixtrajectory::Constraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/Constraint.h
+++ b/helixtrajectorycpp/src/include/constraint/Constraint.h
@@ -5,6 +5,8 @@
 #include <optional>
 #include <variant>
 
+#include <fmt/format.h>
+
 #include "constraint/HeadingConstraint.h"
 #include "constraint/ObstacleConstraint.h"
 #include "constraint/PoseConstraint.h"
@@ -93,8 +95,21 @@ template<>
 struct fmt::formatter<helixtrajectory::Constraint> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::Constraint& constraint, FormatContext& ctx);
+    auto format(const helixtrajectory::Constraint& constraint, FormatContext& ctx) {
+        using namespace helixtrajectory;
+        if (constraint.IsTranslationConstraint()) {
+            return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetTranslationConstraint());
+        } else if (constraint.IsHeadingConstraint()) {
+            return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetHeadingConstraint());
+        } else if (constraint.IsPoseConstraint()) {
+            return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetPoseConstraint());
+        } else /*if (constraint.IsObstacleConstraint())*/ {
+            return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetObstacleConstraint());
+        }
+    }
 };

--- a/helixtrajectorycpp/src/include/constraint/HeadingConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/HeadingConstraint.h
@@ -23,8 +23,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::HeadingConstraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/HeadingConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/HeadingConstraint.h
@@ -2,6 +2,8 @@
 
 #include <optional>
 
+#include <fmt/format.h>
+
 #include "set/IntervalSet1d.h"
 #include "solution/SolutionChecking.h"
 
@@ -22,8 +24,12 @@ template<>
 struct fmt::formatter<helixtrajectory::HeadingConstraint> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::HeadingConstraint& headingConstraint, FormatContext& ctx);
+    auto format(const helixtrajectory::HeadingConstraint& headingConstraint, FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "heading {}", headingConstraint.headingBound);
+    }
 };

--- a/helixtrajectorycpp/src/include/constraint/HolonomicConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/HolonomicConstraint.h
@@ -39,8 +39,7 @@ private:
 template<>
 struct fmt::formatter<helixtrajectory::HolonomicConstraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/HolonomicConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/HolonomicConstraint.h
@@ -40,8 +40,16 @@ template<>
 struct fmt::formatter<helixtrajectory::HolonomicConstraint> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::HolonomicConstraint& constraint, FormatContext& ctx);
+    auto format(const helixtrajectory::HolonomicConstraint& constraint, FormatContext& ctx) {
+        if (constraint.IsVelocityConstraint()) {
+            return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetVelocityConstraint());
+        } else /*if (constraint.IsHeadingConstraint())*/ {
+            return fmt::format_to(ctx.out(), "constraint: {}", constraint.GetAngularVelocityConstraint());
+        }
+    }
 };

--- a/helixtrajectorycpp/src/include/constraint/ObstacleConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/ObstacleConstraint.h
@@ -18,9 +18,13 @@ template<>
 struct fmt::formatter<helixtrajectory::ObstacleConstraint> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
     auto format(const helixtrajectory::ObstacleConstraint& obstacleConstraint,
-            FormatContext& ctx);
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "obstacle constraint");
+    }
 };

--- a/helixtrajectorycpp/src/include/constraint/ObstacleConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/ObstacleConstraint.h
@@ -17,8 +17,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::ObstacleConstraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/PoseConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/PoseConstraint.h
@@ -2,6 +2,8 @@
 
 #include <optional>
 
+#include <fmt/format.h>
+
 #include "constraint/HeadingConstraint.h"
 #include "constraint/TranslationConstraint.h"
 #include "set/IntervalSet1d.h"
@@ -19,3 +21,18 @@ public:
             const SolutionTolerances& tolerances) const noexcept;
 };
 }
+
+template<>
+struct fmt::formatter<helixtrajectory::PoseConstraint> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const helixtrajectory::PoseConstraint& poseConstraint,
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "obstacle constraint");
+    }
+};

--- a/helixtrajectorycpp/src/include/constraint/PoseConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/PoseConstraint.h
@@ -25,8 +25,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::PoseConstraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/TranslationConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/TranslationConstraint.h
@@ -22,8 +22,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::TranslationConstraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/TranslationConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/TranslationConstraint.h
@@ -2,6 +2,8 @@
 
 #include <optional>
 
+#include <fmt/format.h>
+
 #include "set/Set2d.h"
 #include "solution/SolutionChecking.h"
 
@@ -21,9 +23,13 @@ template<>
 struct fmt::formatter<helixtrajectory::TranslationConstraint> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
     auto format(const helixtrajectory::TranslationConstraint& translationConstraint,
-            FormatContext& ctx);
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "translation {}", translationConstraint.translationBound);
+    }
 };

--- a/helixtrajectorycpp/src/include/constraint/VelocityConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/VelocityConstraint.h
@@ -26,8 +26,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::VelocityConstraint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/constraint/VelocityConstraint.h
+++ b/helixtrajectorycpp/src/include/constraint/VelocityConstraint.h
@@ -27,9 +27,13 @@ template<>
 struct fmt::formatter<helixtrajectory::VelocityConstraint> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
     auto format(const helixtrajectory::VelocityConstraint& velocityConstraint,
-            FormatContext& ctx);
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "velocity {}", velocityConstraint.velocityBound);
+    }
 };

--- a/helixtrajectorycpp/src/include/drivetrain/SwerveDrivetrain.h
+++ b/helixtrajectorycpp/src/include/drivetrain/SwerveDrivetrain.h
@@ -60,8 +60,7 @@ namespace helixtrajectory {
 template<>
 struct fmt::formatter<helixtrajectory::SwerveDrivetrain> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/drivetrain/SwerveDrivetrain.h
+++ b/helixtrajectorycpp/src/include/drivetrain/SwerveDrivetrain.h
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "drivetrain/HolonomicDrivetrain.h"
 #include "drivetrain/SwerveModule.h"
 #include "obstacle/Obstacle.h"
@@ -51,3 +53,25 @@ namespace helixtrajectory {
         friend std::ostream& operator<<(std::ostream& stream, const SwerveDrivetrain& swerveDrivetrain);
     };
 }
+
+template<>
+struct fmt::formatter<helixtrajectory::SwerveDrivetrain> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const helixtrajectory::SwerveDrivetrain& swerveDrivetrain,
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(),
+            "swerve drivetrain:\n"
+            "  mass = {},\n"
+            "  moi = {},\n"
+            "  modules = {}",
+                swerveDrivetrain.mass,
+                swerveDrivetrain.momentOfInertia,
+                fmt::join(swerveDrivetrain.modules, ",\n    "));
+    }
+};

--- a/helixtrajectorycpp/src/include/drivetrain/SwerveDrivetrain.h
+++ b/helixtrajectorycpp/src/include/drivetrain/SwerveDrivetrain.h
@@ -4,6 +4,9 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
+#include <fmt/core.h>
 
 #include "drivetrain/HolonomicDrivetrain.h"
 #include "drivetrain/SwerveModule.h"
@@ -69,9 +72,8 @@ struct fmt::formatter<helixtrajectory::SwerveDrivetrain> {
             "swerve drivetrain:\n"
             "  mass = {},\n"
             "  moi = {},\n"
-            "  modules = {}",
+            "  modules = (no impl yet)",
                 swerveDrivetrain.mass,
-                swerveDrivetrain.momentOfInertia,
-                fmt::join(swerveDrivetrain.modules, ",\n    "));
+                swerveDrivetrain.momentOfInertia);
     }
 };

--- a/helixtrajectorycpp/src/include/drivetrain/SwerveModule.h
+++ b/helixtrajectorycpp/src/include/drivetrain/SwerveModule.h
@@ -70,3 +70,23 @@ namespace helixtrajectory {
         friend std::ostream& operator<<(std::ostream& stream, const SwerveModule& module);
     };
 }
+
+template<>
+struct fmt::formatter<helixtrajectory::SwerveModule> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const helixtrajectory::SwerveModule& swerveModule,
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(),
+            "swerve module: (x, y) = ({}, {}), r = {}, ωₘₐₓ = {}, τₘₐₓ = {}",
+                swerveModule.x, swerveModule.y,
+                swerveModule.wheelRadius,
+                swerveModule.wheelMaxAngularVelocity,
+                swerveModule.wheelMaxTorque);
+    }
+};

--- a/helixtrajectorycpp/src/include/drivetrain/SwerveModule.h
+++ b/helixtrajectorycpp/src/include/drivetrain/SwerveModule.h
@@ -74,8 +74,7 @@ namespace helixtrajectory {
 template<>
 struct fmt::formatter<helixtrajectory::SwerveModule> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/path/HolonomicPath.h
+++ b/helixtrajectorycpp/src/include/path/HolonomicPath.h
@@ -67,3 +67,19 @@ namespace helixtrajectory {
         friend std::ostream& operator<<(std::ostream& stream, const HolonomicPath& path);
     };
 }
+
+template<>
+struct fmt::formatter<helixtrajectory::HolonomicPath> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const helixtrajectory::HolonomicPath& holonomicPath,
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(),
+            "Holonomic Path");
+    }
+};

--- a/helixtrajectorycpp/src/include/path/HolonomicPath.h
+++ b/helixtrajectorycpp/src/include/path/HolonomicPath.h
@@ -71,8 +71,7 @@ namespace helixtrajectory {
 template<>
 struct fmt::formatter<helixtrajectory::HolonomicPath> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/path/HolonomicWaypoint.h
+++ b/helixtrajectorycpp/src/include/path/HolonomicWaypoint.h
@@ -85,8 +85,7 @@ namespace helixtrajectory {
 template<>
 struct fmt::formatter<helixtrajectory::HolonomicWaypoint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/path/HolonomicWaypoint.h
+++ b/helixtrajectorycpp/src/include/path/HolonomicWaypoint.h
@@ -81,3 +81,19 @@ namespace helixtrajectory {
         friend std::ostream& operator<<(std::ostream& stream, const HolonomicWaypoint& waypoint);
     };
 }
+
+template<>
+struct fmt::formatter<helixtrajectory::HolonomicWaypoint> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const helixtrajectory::HolonomicWaypoint& holonomicWaypoint,
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(),
+            "Holonomic Waypoint");
+    }
+};

--- a/helixtrajectorycpp/src/include/path/InitialGuessPoint.h
+++ b/helixtrajectorycpp/src/include/path/InitialGuessPoint.h
@@ -27,3 +27,19 @@ namespace helixtrajectory {
         friend std::ostream& operator<<(std::ostream& stream, const InitialGuessPoint& guessPoint);
     };
 }
+
+template<>
+struct fmt::formatter<helixtrajectory::InitialGuessPoint> {
+
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const helixtrajectory::InitialGuessPoint& initialGuessPoint,
+            FormatContext& ctx) {
+        return fmt::format_to(ctx.out(),
+            "Initial Guess Point");
+    }
+};

--- a/helixtrajectorycpp/src/include/path/InitialGuessPoint.h
+++ b/helixtrajectorycpp/src/include/path/InitialGuessPoint.h
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+#include <fmt/format.h>
+
 namespace helixtrajectory {
 
     /**

--- a/helixtrajectorycpp/src/include/path/InitialGuessPoint.h
+++ b/helixtrajectorycpp/src/include/path/InitialGuessPoint.h
@@ -33,8 +33,7 @@ namespace helixtrajectory {
 template<>
 struct fmt::formatter<helixtrajectory::InitialGuessPoint> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/set/ConeSet2d.h
+++ b/helixtrajectorycpp/src/include/set/ConeSet2d.h
@@ -22,8 +22,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::ConeSet2d> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/set/ConeSet2d.h
+++ b/helixtrajectorycpp/src/include/set/ConeSet2d.h
@@ -23,8 +23,12 @@ template<>
 struct fmt::formatter<helixtrajectory::ConeSet2d> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::ConeSet2d& coneSet, FormatContext& ctx);
+    auto format(const helixtrajectory::ConeSet2d& coneSet, FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "cone: θ = {}", coneSet.thetaBound);
+    }
 };

--- a/helixtrajectorycpp/src/include/set/EllipticalSet2d.h
+++ b/helixtrajectorycpp/src/include/set/EllipticalSet2d.h
@@ -36,8 +36,32 @@ template<>
 struct fmt::formatter<helixtrajectory::EllipticalSet2d> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::EllipticalSet2d& ellipticalSet, FormatContext& ctx);
+    auto format(const helixtrajectory::EllipticalSet2d& ellipticalSet, FormatContext& ctx) {
+        std::string shape;
+        if (ellipticalSet.IsCircular()) {
+            shape = "circle";
+        } else {
+            shape = "ellipse";
+        }
+        using enum helixtrajectory::EllipticalSet2d::Direction;
+        std::string direction;
+        switch (ellipticalSet.direction) {
+            case kInside:
+                direction = "inside";
+                break;
+            case kCentered:
+                direction = "centered";
+                break;
+            case kOutside:
+                direction = "outside";
+                break;
+        }
+        return fmt::format_to(ctx.out(), "{}: {}, rₓ = {}, rᵧ = {}",
+                shape, direction, ellipticalSet.xRadius, ellipticalSet.yRadius);
+    }
 };

--- a/helixtrajectorycpp/src/include/set/EllipticalSet2d.h
+++ b/helixtrajectorycpp/src/include/set/EllipticalSet2d.h
@@ -35,8 +35,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::EllipticalSet2d> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/set/IntervalSet1d.h
+++ b/helixtrajectorycpp/src/include/set/IntervalSet1d.h
@@ -96,8 +96,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::IntervalSet1d> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/set/IntervalSet1d.h
+++ b/helixtrajectorycpp/src/include/set/IntervalSet1d.h
@@ -97,8 +97,16 @@ template<>
 struct fmt::formatter<helixtrajectory::IntervalSet1d> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::IntervalSet1d& set1d, FormatContext& ctx);
+    auto format(const helixtrajectory::IntervalSet1d& set1d, FormatContext& ctx) {
+        if (set1d.IsExact()) {
+            return fmt::format_to(ctx.out(), "= {}", set1d.lower);
+        } else {
+            return fmt::format_to(ctx.out(), "∈ [{}, {}]", set1d.lower, set1d.upper);
+        }
+    }
 };

--- a/helixtrajectorycpp/src/include/set/LinearSet2d.h
+++ b/helixtrajectorycpp/src/include/set/LinearSet2d.h
@@ -25,8 +25,12 @@ template<>
 struct fmt::formatter<helixtrajectory::LinearSet2d> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::LinearSet2d& linearSet, FormatContext& ctx);
+    auto format(const helixtrajectory::LinearSet2d& linearSet, FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "polar line: θ = {}", linearSet.theta);
+    }
 };

--- a/helixtrajectorycpp/src/include/set/LinearSet2d.h
+++ b/helixtrajectorycpp/src/include/set/LinearSet2d.h
@@ -24,8 +24,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::LinearSet2d> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/set/RectangularSet2d.h
+++ b/helixtrajectorycpp/src/include/set/RectangularSet2d.h
@@ -34,8 +34,12 @@ template<>
 struct fmt::formatter<helixtrajectory::RectangularSet2d> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::RectangularSet2d& rectangularSet, FormatContext& ctx);
+    auto format(const helixtrajectory::RectangularSet2d& rectangularSet, FormatContext& ctx) {
+        return fmt::format_to(ctx.out(), "x {}, y {}", rectangularSet.xBound, rectangularSet.yBound);
+    }
 };

--- a/helixtrajectorycpp/src/include/set/RectangularSet2d.h
+++ b/helixtrajectorycpp/src/include/set/RectangularSet2d.h
@@ -33,8 +33,7 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::RectangularSet2d> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/set/Set2d.h
+++ b/helixtrajectorycpp/src/include/set/Set2d.h
@@ -69,8 +69,7 @@ private:
 template<>
 struct fmt::formatter<helixtrajectory::Set2d> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/set/Set2d.h
+++ b/helixtrajectorycpp/src/include/set/Set2d.h
@@ -70,8 +70,21 @@ template<>
 struct fmt::formatter<helixtrajectory::Set2d> {
 
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::Set2d& set2d, FormatContext& ctx);
+    auto format(const helixtrajectory::Set2d& set2d, FormatContext& ctx) {
+        using namespace helixtrajectory;
+        if (set2d.IsRectangular()) {
+            return fmt::format_to(ctx.out(), "2d {}", set2d.GetRectangular());
+        } else if (set2d.IsLinear()) {
+            return fmt::format_to(ctx.out(), "2d {}", set2d.GetLinear());
+        } else if (set2d.IsElliptical()) {
+            return fmt::format_to(ctx.out(), "2d {}", set2d.GetElliptical());
+        } else /*if (set2d.IsCone())*/ {
+            return fmt::format_to(ctx.out(), "2d {}", set2d.GetCone());
+        }
+    }
 };

--- a/helixtrajectorycpp/src/include/solution/SwerveSolution.h
+++ b/helixtrajectorycpp/src/include/solution/SwerveSolution.h
@@ -18,8 +18,7 @@ struct SwerveSolution : HolonomicSolution {
 template<>
 struct fmt::formatter<helixtrajectory::SwerveSolution> {
 
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectory.h
+++ b/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectory.h
@@ -19,8 +19,8 @@ public:
 
 template<>
 struct fmt::formatter<helixtrajectory::HolonomicTrajectory> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectory.h
+++ b/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectory.h
@@ -28,7 +28,7 @@ struct fmt::formatter<helixtrajectory::HolonomicTrajectory> {
     auto format(const helixtrajectory::HolonomicTrajectory& trajectory, FormatContext& ctx) {
         std::string sampsStr = fmt::format("{}", trajectory.samples[0]);
         for (int i = 1; i < trajectory.samples.size(); i++) {
-            sampsStr += fmt::format(", {}", sample);
+            sampsStr += fmt::format(", {}", trajectory.samples[i]);
         }
         return fmt::format_to(ctx.out(), "[{}]", sampsStr);
     }

--- a/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectory.h
+++ b/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectory.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <vector>
 
 #include <fmt/format.h>
@@ -21,8 +20,16 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::HolonomicTrajectory> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::HolonomicTrajectory& trajectory, FormatContext& ctx);
+    auto format(const helixtrajectory::HolonomicTrajectory& trajectory, FormatContext& ctx) {
+        std::string sampsStr = fmt::format("{}", trajectory.samples[0]);
+        for (int i = 1; i < trajectory.samples.size(); i++) {
+            sampsStr += fmt::format(", {}", sample);
+        }
+        return fmt::format_to(ctx.out(), "[{}]", sampsStr);
+    }
 };

--- a/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectorySample.h
+++ b/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectorySample.h
@@ -31,8 +31,8 @@ public:
 
 template<>
 struct fmt::formatter<helixtrajectory::HolonomicTrajectorySample> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         return ctx.begin();
     }
 

--- a/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectorySample.h
+++ b/helixtrajectorycpp/src/include/trajectory/HolonomicTrajectorySample.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+
 #include <fmt/format.h>
 
 namespace helixtrajectory {
@@ -31,8 +32,16 @@ public:
 template<>
 struct fmt::formatter<helixtrajectory::HolonomicTrajectorySample> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx);
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
-    auto format(const helixtrajectory::HolonomicTrajectorySample& sample, FormatContext& ctx);
+    auto format(const helixtrajectory::HolonomicTrajectorySample& sample, FormatContext& ctx) {
+        return fmt::format_to(ctx.out(),
+            "{{\"timestamp\": {}, \"x\": {}, \"y\": {}, \"heading\": {}, \"velocityX\": {}, \"velocityY\": {}, \"angularVelocity\": {}}}",
+                sample.timestamp,
+                sample.x, sample.y, sample.heading,
+                sample.velocityX, sample.velocityY, sample.angularVelocity);
+    }
 };


### PR DESCRIPTION
Created {fmt} templates for format strings for most types in the API.