### PR TITLE
Improve initial guess API

### DIFF
--- a/include/path/SwervePathBuilder.h
+++ b/include/path/SwervePathBuilder.h
@@ -71,14 +71,13 @@ class TRAJOPT_DLLEXPORT SwervePathBuilder {
 
   /**
    * Add a sequence of initial guess points between two waypoints. The points
-   * are inserted between the waypoints at fromIdx and (fromIdx + 1).
-   Interpolation
-   * between the waypoint initial guess points and these segment initial guess
-   points
-   * is used as the initial guess of the robot's pose over the trajectory.
+   * are inserted between the waypoints at fromIdx and fromIdx + 1. Linear
+   * interpolation between the waypoint initial guess points and these segment
+   * initial guess points is used as the initial guess of the robot's pose over
+   * the trajectory.
    *
    * @param fromIdx index of the waypoint the initial guess point
-                    comes immediately after
+   *                 comes immediately after
    * @param sgmtPoseGuess the sequence of initial guess points
    */
   void SgmtInitialGuessPoints(

--- a/include/path/SwervePathBuilder.h
+++ b/include/path/SwervePathBuilder.h
@@ -63,7 +63,7 @@ class TRAJOPT_DLLEXPORT SwervePathBuilder {
 
   /**
    * Provide a guess of the instantaneous pose of the robot at a waypoint.
-   * 
+   *
    * @param wptIdx the waypoint to apply the guess to
    * @param poseGuess the guess of the robot's pose
    */
@@ -71,15 +71,18 @@ class TRAJOPT_DLLEXPORT SwervePathBuilder {
 
   /**
    * Add a sequence of initial guess points between two waypoints. The points
-   * are inserted between the waypoints at fromIdx and (fromIdx + 1). Interpolation
-   * between the waypoint initial guess points and these segment initial guess points
+   * are inserted between the waypoints at fromIdx and (fromIdx + 1).
+   Interpolation
+   * between the waypoint initial guess points and these segment initial guess
+   points
    * is used as the initial guess of the robot's pose over the trajectory.
    *
    * @param fromIdx index of the waypoint the initial guess point
                     comes immediately after
    * @param sgmtPoseGuess the sequence of initial guess points
    */
-  void SgmtInitialGuessPoints(size_t fromIdx, const std::vector<InitialGuessPoint>& sgmtPoseGuess);
+  void SgmtInitialGuessPoints(
+      size_t fromIdx, const std::vector<InitialGuessPoint>& sgmtPoseGuess);
 
   /**
    * Specify the required direction of the velocity vector of the robot

--- a/include/path/SwervePathBuilder.h
+++ b/include/path/SwervePathBuilder.h
@@ -61,17 +61,23 @@ class TRAJOPT_DLLEXPORT SwervePathBuilder {
   void TranslationWpt(size_t idx, double x, double y,
                       double headingGuess = 0.0);
 
+  /**
+   * Provide a guess of the instantaneous pose of the robot at a waypoint.
+   * 
+   * @param wptIdx the waypoint to apply the guess to
+   * @param poseGuess the guess of the robot's pose
+   */
   void WptInitialGuessPoint(size_t wptIdx, const InitialGuessPoint& poseGuess);
 
   /**
-   * Add an initial guess point between two waypoints. The initial guess
-   * point is inserted between the waypoints at fromIdx and (fromIdx + 1).
+   * Add a sequence of initial guess points between two waypoints. The points
+   * are inserted between the waypoints at fromIdx and (fromIdx + 1). Interpolation
+   * between the waypoint initial guess points and these segment initial guess points
+   * is used as the initial guess of the robot's pose over the trajectory.
    *
    * @param fromIdx index of the waypoint the initial guess point
                     comes immediately after
-   * @param x guess of x
-   * @param y guess of y
-   * @param heading guess of heading
+   * @param sgmtPoseGuess the sequence of initial guess points
    */
   void SgmtInitialGuessPoints(size_t fromIdx, const std::vector<InitialGuessPoint>& sgmtPoseGuess);
 

--- a/include/path/SwervePathBuilder.h
+++ b/include/path/SwervePathBuilder.h
@@ -61,6 +61,8 @@ class TRAJOPT_DLLEXPORT SwervePathBuilder {
   void TranslationWpt(size_t idx, double x, double y,
                       double headingGuess = 0.0);
 
+  void WptInitialGuessPoint(size_t wptIdx, const InitialGuessPoint& poseGuess);
+
   /**
    * Add an initial guess point between two waypoints. The initial guess
    * point is inserted between the waypoints at fromIdx and (fromIdx + 1).
@@ -71,7 +73,7 @@ class TRAJOPT_DLLEXPORT SwervePathBuilder {
    * @param y guess of y
    * @param heading guess of heading
    */
-  void AddInitialGuessPoint(size_t fromIdx, double x, double y, double heading);
+  void SgmtInitialGuessPoints(size_t fromIdx, const std::vector<InitialGuessPoint>& sgmtPoseGuess);
 
   /**
    * Specify the required direction of the velocity vector of the robot

--- a/src/path/SwervePathBuilder.cpp
+++ b/src/path/SwervePathBuilder.cpp
@@ -41,7 +41,7 @@ void SwervePathBuilder::PoseWpt(size_t index, double x, double y,
       TranslationConstraint{RectangularSet2d{x, y}});
   path.waypoints.at(index).waypointConstraints.emplace_back(
       HeadingConstraint{heading});
-  initialGuessPoints.at(index).emplace_back(InitialGuessPoint{x, y, heading});
+  initialGuessPoints.at(index).back() = InitialGuessPoint{x, y, heading};
 }
 
 void SwervePathBuilder::TranslationWpt(size_t index, double x, double y,
@@ -49,15 +49,20 @@ void SwervePathBuilder::TranslationWpt(size_t index, double x, double y,
   NewWpts(index);
   path.waypoints.at(index).waypointConstraints.emplace_back(
       TranslationConstraint{RectangularSet2d{x, y}});
-  initialGuessPoints.at(index).emplace_back(
-      InitialGuessPoint{x, y, headingGuess});
+  initialGuessPoints.at(index).back() = InitialGuessPoint{x, y, headingGuess};
 }
 
-void SwervePathBuilder::AddInitialGuessPoint(size_t fromIdx, double x, double y,
-                                             double heading) {
+void SwervePathBuilder::WptInitialGuessPoint(size_t wptIdx, const InitialGuessPoint& poseGuess) {
+  NewWpts(wptIdx);
+  initialGuessPoints.at(wptIdx).back() = poseGuess;
+}
+
+void SwervePathBuilder::SgmtInitialGuessPoints(size_t fromIdx, const std::vector<InitialGuessPoint>& sgmtPoseGuess) {
   NewWpts(fromIdx + 1);
-  initialGuessPoints.at(fromIdx + 1)
-      .push_back(InitialGuessPoint{x, y, heading});
+  std::vector<InitialGuessPoint>& toInitialGuessPoints
+      = initialGuessPoints.at(fromIdx + 1);
+  toInitialGuessPoints.insert(toInitialGuessPoints.begin(),
+      sgmtPoseGuess.begin(), sgmtPoseGuess.end());
 }
 
 void SwervePathBuilder::WptVelocityDirection(size_t idx, double angle) {
@@ -174,7 +179,7 @@ void SwervePathBuilder::NewWpts(size_t finalIndex) {
   if (targetIdx > greatestIdx) {
     for (int64_t i = greatestIdx + 1; i <= targetIdx; i++) {
       path.waypoints.emplace_back(SwerveWaypoint{});
-      initialGuessPoints.emplace_back(std::vector<InitialGuessPoint>{});
+      initialGuessPoints.emplace_back(std::vector{InitialGuessPoint{0.0, 0.0, 0.0}});
       controlIntervalCounts.push_back(i == 0 ? 0 : 40);
     }
   }

--- a/src/path/SwervePathBuilder.cpp
+++ b/src/path/SwervePathBuilder.cpp
@@ -41,7 +41,7 @@ void SwervePathBuilder::PoseWpt(size_t index, double x, double y,
       TranslationConstraint{RectangularSet2d{x, y}});
   path.waypoints.at(index).waypointConstraints.emplace_back(
       HeadingConstraint{heading});
-  initialGuessPoints.at(index).back() = InitialGuessPoint{x, y, heading};
+  WptInitialGuessPoint(index, InitialGuessPoint{x, y, heading});
 }
 
 void SwervePathBuilder::TranslationWpt(size_t index, double x, double y,
@@ -49,7 +49,7 @@ void SwervePathBuilder::TranslationWpt(size_t index, double x, double y,
   NewWpts(index);
   path.waypoints.at(index).waypointConstraints.emplace_back(
       TranslationConstraint{RectangularSet2d{x, y}});
-  initialGuessPoints.at(index).back() = InitialGuessPoint{x, y, headingGuess};
+  WptInitialGuessPoint(index, InitialGuessPoint{x, y, headingGuess});
 }
 
 void SwervePathBuilder::WptInitialGuessPoint(

--- a/src/path/SwervePathBuilder.cpp
+++ b/src/path/SwervePathBuilder.cpp
@@ -52,17 +52,19 @@ void SwervePathBuilder::TranslationWpt(size_t index, double x, double y,
   initialGuessPoints.at(index).back() = InitialGuessPoint{x, y, headingGuess};
 }
 
-void SwervePathBuilder::WptInitialGuessPoint(size_t wptIdx, const InitialGuessPoint& poseGuess) {
+void SwervePathBuilder::WptInitialGuessPoint(
+    size_t wptIdx, const InitialGuessPoint& poseGuess) {
   NewWpts(wptIdx);
   initialGuessPoints.at(wptIdx).back() = poseGuess;
 }
 
-void SwervePathBuilder::SgmtInitialGuessPoints(size_t fromIdx, const std::vector<InitialGuessPoint>& sgmtPoseGuess) {
+void SwervePathBuilder::SgmtInitialGuessPoints(
+    size_t fromIdx, const std::vector<InitialGuessPoint>& sgmtPoseGuess) {
   NewWpts(fromIdx + 1);
-  std::vector<InitialGuessPoint>& toInitialGuessPoints
-      = initialGuessPoints.at(fromIdx + 1);
+  std::vector<InitialGuessPoint>& toInitialGuessPoints =
+      initialGuessPoints.at(fromIdx + 1);
   toInitialGuessPoints.insert(toInitialGuessPoints.begin(),
-      sgmtPoseGuess.begin(), sgmtPoseGuess.end());
+                              sgmtPoseGuess.begin(), sgmtPoseGuess.end());
 }
 
 void SwervePathBuilder::WptVelocityDirection(size_t idx, double angle) {
@@ -179,7 +181,8 @@ void SwervePathBuilder::NewWpts(size_t finalIndex) {
   if (targetIdx > greatestIdx) {
     for (int64_t i = greatestIdx + 1; i <= targetIdx; i++) {
       path.waypoints.emplace_back(SwerveWaypoint{});
-      initialGuessPoints.emplace_back(std::vector{InitialGuessPoint{0.0, 0.0, 0.0}});
+      initialGuessPoints.emplace_back(
+          std::vector{InitialGuessPoint{0.0, 0.0, 0.0}});
       controlIntervalCounts.push_back(i == 0 ? 0 : 40);
     }
   }

--- a/test/src/SwervePathBuilderTest.cpp
+++ b/test/src/SwervePathBuilderTest.cpp
@@ -10,17 +10,19 @@
 TEST(SwervePathBuilderTest, GenerateLinearInitialGuess) {
   using namespace trajopt;
   trajopt::SwervePathBuilder path;
-  path.WptInitialGuessPoint(0, InitialGuessPoint{0.0, 0.0, 0.0}); // at 0
+  path.WptInitialGuessPoint(0, InitialGuessPoint{0.0, 0.0, 0.0});  // at 0
 
-  path.SgmtInitialGuessPoints(0, {InitialGuessPoint{1.0, 0.0, 0.0}, InitialGuessPoint{2.0, 0.0, 0.0}}); // from 0 to 1
-  path.WptInitialGuessPoint(1, InitialGuessPoint{1.0, 0.0, 0.0}); // at 1
+  path.SgmtInitialGuessPoints(
+      0, {InitialGuessPoint{1.0, 0.0, 0.0},
+          InitialGuessPoint{2.0, 0.0, 0.0}});  // from 0 to 1
+  path.WptInitialGuessPoint(1, InitialGuessPoint{1.0, 0.0, 0.0});  // at 1
 
-  path.WptInitialGuessPoint(2, InitialGuessPoint{5.0, 0.0, 0.0}); // at 2
+  path.WptInitialGuessPoint(2, InitialGuessPoint{5.0, 0.0, 0.0});  // at 2
 
   path.ControlIntervalCounts({3, 2});
 
   std::vector<double> result = path.CalculateInitialGuess().x;
   std::vector<double> expected = {0.0, 1.0, 2.0, 1.0, 3.0, 5.0};
-  
+
   ASSERT_EQ(result, expected);
 }

--- a/test/src/SwervePathBuilderTest.cpp
+++ b/test/src/SwervePathBuilderTest.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) TrajoptLib contributors
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "path/InitialGuessPoint.h"
+#include "path/SwervePathBuilder.h"
+
+TEST(SwervePathBuilderTest, GenerateLinearInitialGuess) {
+  using namespace trajopt;
+  trajopt::SwervePathBuilder path;
+  path.WptInitialGuessPoint(0, InitialGuessPoint{0.0, 0.0, 0.0}); // at 0
+
+  path.SgmtInitialGuessPoints(0, {InitialGuessPoint{1.0, 0.0, 0.0}, InitialGuessPoint{2.0, 0.0, 0.0}}); // from 0 to 1
+  path.WptInitialGuessPoint(1, InitialGuessPoint{1.0, 0.0, 0.0}); // at 1
+
+  path.WptInitialGuessPoint(2, InitialGuessPoint{5.0, 0.0, 0.0}); // at 2
+
+  path.ControlIntervalCounts({3, 2});
+
+  std::vector<double> result = path.CalculateInitialGuess().x;
+  std::vector<double> expected = {0.0, 1.0, 2.0, 1.0, 3.0, 5.0};
+  
+  ASSERT_EQ(result, expected);
+}


### PR DESCRIPTION
The current API does not have a way of setting the initial guess of the first waypoint without using the `TranslationWpt()` or `PoseWpt()` functions. This PR improves code readability and solves this problem simultaneously.

One of the main goals of the new API was to remove ambiguity by avoiding the fencepost problem. However, even in the new API, the `AddInitialGuessPoint()` function was ambiguous about how the linearly interpolated initial guess was created from the points. While I could have just documented that the final point the user adds becomes the guess for the robot's pose at the waypoint itself, there is a much better way.

I've introduced two new functions for setting initial guess points rather than just one. That is, `WptInitialGuessPoint()` and `SgmtInitialGuessPoints()`. By having a function to set the initial guess points between to waypoints along with a function to set the initial guess at the waypoint itself, there is no ambiguity. In the current API, it is ambiguous whether the first or last point added becomes the guess for a waypoint itself, but the waypoint initial guess is explicitly stated in this API.

I've also modified the API so that at least one initial guess point is applied to a waypoint at the time of creating it. This avoid the issue where a user might not manually set an initial guess point for a waypoint if it isn't automatically set by `TranslationWpt()` or `PoseWpt`, for example.

Finally, I've provided a unit test that verifies this new functionality.