### PR TITLE
Fix CasADi architecture checks on Unix systems

### DIFF
--- a/cmake/modules/FetchCasADi.cmake
+++ b/cmake/modules/FetchCasADi.cmake
@@ -68,8 +68,8 @@ macro(fetch_casadi)
         endif()
         set(CASADI_INSTALL_DEST "lib")
     elseif(UNIX)
-        if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "ARM64")
-            message(STATUS "Building for Linux arm64")
+        if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+            message(STATUS "Building for Linux aarch64")
             set(CASADI_URL
                 https://github.com/casadi/casadi/releases/download/3.6.4/casadi-3.6.4-linux-aarch64-py311.zip
             )
@@ -84,7 +84,7 @@ macro(fetch_casadi)
                 ${CASADI_LIBDIR}/libcasadi-tp-openblas.so.0
             )
         else()
-            message(STATUS "Building for Linux x64")
+            message(STATUS "Building for Linux x86_64")
             set(CASADI_URL
                 https://github.com/casadi/casadi/releases/download/3.6.4/casadi-3.6.4-linux64-py311.zip
             )


### PR DESCRIPTION
On Unix systems, cmake uses uname to find the system CPU architecture, and for arm64 systems, uname returns aarch64