### PR TITLE
Remove DEBUG_OUTPUT define

### DIFF
--- a/src/DebugOptions.h
+++ b/src/DebugOptions.h
@@ -1,5 +1,0 @@
-// Copyright (c) TrajoptLib contributors
-
-#pragma once
-
-#define DEBUG_OUTPUT

--- a/src/OptimalTrajectoryGenerator.cpp
+++ b/src/OptimalTrajectoryGenerator.cpp
@@ -11,7 +11,6 @@
 #include "optimization/SleipnirOpti.h"
 #define _OPTI_BACKEND SleipnirExpr, SleipnirOpti
 #endif
-#include "DebugOptions.h"
 #include "trajopt/drivetrain/SwerveDrivetrain.h"
 #include "optimization/algorithms/SwerveDiscreteOptimal.h"
 #include "trajopt/solution/SwerveSolution.h"

--- a/src/optimization/CasADiOpti.cpp
+++ b/src/optimization/CasADiOpti.cpp
@@ -4,7 +4,6 @@
 
 #include <casadi/casadi.hpp>
 
-#include "DebugOptions.h"
 #include "optimization/Cancellation.h"
 #include "optimization/CasADiIterCallback.h"
 
@@ -31,14 +30,12 @@ expected<void, std::string> CasADiOpti::Solve() {
   GetCancellationFlag() = 0;
   const auto callback =
       new const CasADiIterCallback("f", opti.nx(), opti.ng(), opti.np());
+
   auto pluginOptions = casadi::Dict();
   pluginOptions["iteration_callback"] = *callback;
-#ifndef DEBUG_OUTPUT
-  auto pluginOptions = casadi::Dict();
   pluginOptions["ipopt.print_level"] = 0;
-  pluginOptions["print_time"] = 0;
   pluginOptions["ipopt.sb"] = "yes";
-#endif
+  pluginOptions["print_time"] = 0;
 
   // I don't try-catch this next line since it should always work.
   // I'm assuming the dynamic lib is on the path and casadi can find it.

--- a/src/optimization/HolonomicTrajoptUtil.inc
+++ b/src/optimization/HolonomicTrajoptUtil.inc
@@ -4,7 +4,6 @@
 
 #include <vector>
 
-#include "DebugOptions.h"
 #include "optimization/HolonomicTrajoptUtil.h"
 #include "optimization/TrajoptUtil.h"
 #include "trajopt/constraint/Constraint.h"

--- a/src/optimization/SleipnirOpti.cpp
+++ b/src/optimization/SleipnirOpti.cpp
@@ -11,7 +11,6 @@
 #include <sleipnir/optimization/Constraints.hpp>
 #include <sleipnir/optimization/OptimizationProblem.hpp>
 
-#include "DebugOptions.h"
 #include "optimization/Cancellation.h"
 
 namespace trajopt {

--- a/src/optimization/SwerveTrajoptUtil.inc
+++ b/src/optimization/SwerveTrajoptUtil.inc
@@ -7,7 +7,6 @@
 #include <utility>
 #include <vector>
 
-#include "DebugOptions.h"
 #include "optimization/SwerveTrajoptUtil.h"
 #include "optimization/TrajoptUtil.h"
 #include "trajopt/drivetrain/SwerveDrivetrain.h"

--- a/src/optimization/TrajoptUtil.inc
+++ b/src/optimization/TrajoptUtil.inc
@@ -11,7 +11,6 @@
 #include <variant>
 #include <vector>
 
-#include "DebugOptions.h"
 #include "optimization/TrajoptUtil.h"
 #include "trajopt/constraint/LinePointConstraint.h"
 #include "trajopt/constraint/PointLineConstraint.h"

--- a/src/optimization/algorithms/SwerveDiscreteOptimal.inc
+++ b/src/optimization/algorithms/SwerveDiscreteOptimal.inc
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "DebugOptions.h"
 #include "optimization/SwerveTrajoptUtil.h"
 #include "optimization/TrajoptUtil.h"
 #include "optimization/algorithms/SwerveDiscreteOptimal.h"


### PR DESCRIPTION
We always want it enabled for user-side diagnostics if the solver fails in Choreo. For direct API usage, a diagnostics flag argument would be better.