### PR TITLE
[build] Lower required cmake version to match Sleipnir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ FATAL: In-source builds are not allowed.
     )
 endif()
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.22)
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ FATAL: In-source builds are not allowed.
     )
 endif()
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.21)
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"


### PR DESCRIPTION
CI is passing so I don't see any reason the required version should be higher than Sleipnir's. Also means I can build on PopOS lts without having to install CMake through something other than the distros repo :smile: 