### PR TITLE
Remove Wasm CI

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-rust:
+  build:
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-cpp:
+  build:
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -74,20 +74,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: pkg
-
-  build-wasm:
-    name: "Wasm"
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: numworks/setup-emscripten@latest
-      - run: emcmake cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DOPTIMIZER_BACKEND=sleipnir
-      - run: cmake --build build --config Release --parallel $(nproc)
-      - run: cmake --install build --config Release --prefix pkg
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: Wasm
           path: pkg


### PR DESCRIPTION
Choreo is the main user of TrajoptLib, and it needs to run in offline contexts. If we're already offline native, we might as well take advantage of it instead of doing JS-only. We get better UI integration and less overhead for the solver.